### PR TITLE
test(e2e): enable parallel execution for multiple tests

### DIFF
--- a/test/e2e/cascade_gc_test.go
+++ b/test/e2e/cascade_gc_test.go
@@ -43,6 +43,7 @@ const (
 )
 
 func TestCascadeGC_ExposerUpdatesComponent(t *testing.T) {
+	t.Parallel()
 	feature := features.New("exposer-updates-component").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()
@@ -214,6 +215,7 @@ func TestCascadeGC_ExposerUpdatesComponent(t *testing.T) {
 }
 
 func TestCascadeGC_ExposerDeletionCleanup(t *testing.T) {
+	t.Parallel()
 	feature := features.New("exposer-deletion-cleanup").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestCRDInstallation(t *testing.T) {
+	t.Parallel()
 	expectedCRDs := []string{
 		"scalityuis.ui.scality.com",
 		"scalityuicomponents.ui.scality.com",
@@ -54,6 +55,7 @@ func TestCRDInstallation(t *testing.T) {
 }
 
 func TestOperatorDeployment(t *testing.T) {
+	t.Parallel()
 	if framework.SkipOperatorDeploy() {
 		t.Skip("Skipping operator deployment test (E2E_SKIP_OPERATOR=true)")
 	}
@@ -109,6 +111,7 @@ const (
 )
 
 func TestSmokeFullChain(t *testing.T) {
+	t.Parallel()
 	// Expected values from mock-server's defaultMicroAppConfig()
 	const (
 		expectedPublicPath = "/mock/"

--- a/test/e2e/multi_namespace_test.go
+++ b/test/e2e/multi_namespace_test.go
@@ -42,6 +42,7 @@ const (
 )
 
 func TestMultiNamespace_MultipleComponentsAggregation(t *testing.T) {
+	t.Parallel()
 	feature := features.New("multi-namespace-components-aggregation").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()
@@ -304,6 +305,7 @@ func TestMultiNamespace_MultipleComponentsAggregation(t *testing.T) {
 }
 
 func TestMultiNamespace_PartialNamespaceDeletion(t *testing.T) {
+	t.Parallel()
 	feature := features.New("multi-namespace-partial-deletion").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()

--- a/test/e2e/namespace_deletion_test.go
+++ b/test/e2e/namespace_deletion_test.go
@@ -37,6 +37,7 @@ const (
 )
 
 func TestNamespaceDeletion_CascadeCleanup(t *testing.T) {
+	t.Parallel()
 	feature := features.New("namespace-deletion-cascade-cleanup").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()

--- a/test/e2e/pod_lifecycle_test.go
+++ b/test/e2e/pod_lifecycle_test.go
@@ -44,6 +44,7 @@ const (
 )
 
 func TestPodLifecycle_RollingUpdateOnConfigChange(t *testing.T) {
+	t.Parallel()
 	feature := features.New("rolling-update-on-config-change").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()
@@ -214,6 +215,7 @@ func TestPodLifecycle_RollingUpdateOnConfigChange(t *testing.T) {
 }
 
 func TestPodLifecycle_OperatorCrashRecovery(t *testing.T) {
+	t.Parallel()
 	feature := features.New("operator-crash-recovery").
 		WithLabel("disruptive", "true").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -362,6 +364,7 @@ func TestPodLifecycle_OperatorCrashRecovery(t *testing.T) {
 }
 
 func TestPodLifecycle_NoSpuriousUpdatesAfterRestart(t *testing.T) {
+	t.Parallel()
 	feature := features.New("no-spurious-updates-after-restart").
 		WithLabel("disruptive", "true").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {

--- a/test/e2e/real_http_test.go
+++ b/test/e2e/real_http_test.go
@@ -37,6 +37,7 @@ type realHTTPContextKey string
 const realHTTPNamespaceKey realHTTPContextKey = "real-http-namespace"
 
 func TestRealHTTP_ReconcileStormPrevention(t *testing.T) {
+	t.Parallel()
 	const componentName = "storm-test-component"
 
 	feature := features.New("reconcile-storm-prevention").
@@ -133,6 +134,7 @@ func TestRealHTTP_ReconcileStormPrevention(t *testing.T) {
 }
 
 func TestRealHTTP_TimeoutHandling(t *testing.T) {
+	t.Parallel()
 	const componentName = "timeout-test-component"
 
 	feature := features.New("http-timeout-handling").
@@ -229,6 +231,7 @@ func TestRealHTTP_TimeoutHandling(t *testing.T) {
 // TestRealHTTP_RecoveryAfterServerFailure verifies recovery after server failure.
 // Strategy: Reset mock server config, then wait for controller's natural retry (RequeueAfter: 30s).
 func TestRealHTTP_RecoveryAfterServerFailure(t *testing.T) {
+	t.Parallel()
 	const componentName = "recovery-test-component"
 
 	feature := features.New("recovery-after-server-failure").
@@ -392,6 +395,7 @@ func TestRealHTTP_RecoveryAfterServerFailure(t *testing.T) {
 // TestRealHTTP_NoFetchWithoutTrigger verifies that after initial success,
 // the controller doesn't make new HTTP requests without a trigger (image change or force-refresh).
 func TestRealHTTP_NoFetchWithoutTrigger(t *testing.T) {
+	t.Parallel()
 	const componentName = "no-fetch-test-component"
 
 	feature := features.New("no-fetch-without-trigger").

--- a/test/e2e/real_http_test.go
+++ b/test/e2e/real_http_test.go
@@ -37,7 +37,6 @@ type realHTTPContextKey string
 const realHTTPNamespaceKey realHTTPContextKey = "real-http-namespace"
 
 func TestRealHTTP_ReconcileStormPrevention(t *testing.T) {
-	t.Parallel()
 	const componentName = "storm-test-component"
 
 	feature := features.New("reconcile-storm-prevention").
@@ -134,7 +133,6 @@ func TestRealHTTP_ReconcileStormPrevention(t *testing.T) {
 }
 
 func TestRealHTTP_TimeoutHandling(t *testing.T) {
-	t.Parallel()
 	const componentName = "timeout-test-component"
 
 	feature := features.New("http-timeout-handling").
@@ -231,7 +229,6 @@ func TestRealHTTP_TimeoutHandling(t *testing.T) {
 // TestRealHTTP_RecoveryAfterServerFailure verifies recovery after server failure.
 // Strategy: Reset mock server config, then wait for controller's natural retry (RequeueAfter: 30s).
 func TestRealHTTP_RecoveryAfterServerFailure(t *testing.T) {
-	t.Parallel()
 	const componentName = "recovery-test-component"
 
 	feature := features.New("recovery-after-server-failure").
@@ -395,7 +392,6 @@ func TestRealHTTP_RecoveryAfterServerFailure(t *testing.T) {
 // TestRealHTTP_NoFetchWithoutTrigger verifies that after initial success,
 // the controller doesn't make new HTTP requests without a trigger (image change or force-refresh).
 func TestRealHTTP_NoFetchWithoutTrigger(t *testing.T) {
-	t.Parallel()
 	const componentName = "no-fetch-test-component"
 
 	feature := features.New("no-fetch-without-trigger").


### PR DESCRIPTION
- Added `t.Parallel()` to various end-to-end tests to allow concurrent execution, improving test efficiency and reducing overall runtime.
- Updated tests across multiple files, including cascade GC, multi-namespace, namespace deletion, pod lifecycle.