### PR TITLE
use GIT_ACCESS_TOKEN instead of GH_PAT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: boolean
     secrets:
-      GH_PAT:
+      GIT_ACCESS_TOKEN:
         description: "A GitHub PAT with permissions to read the private repository."
         required: true
 
@@ -85,7 +85,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            GH_TOKEN=${{ secrets.GH_PAT }}
+            GH_TOKEN=${{ secrets.GIT_ACCESS_TOKEN }}
             PRIVATE_REPO_HOST=github.com/scality
             BUILD_DATE=${{ fromJson(steps.meta.outputs.json)['org.opencontainers.image.created'] }}
             GIT_COMMIT=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,12 +85,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            GH_TOKEN=${{ secrets.GIT_ACCESS_TOKEN }}
             PRIVATE_REPO_HOST=github.com/scality
             BUILD_DATE=${{ fromJson(steps.meta.outputs.json)['org.opencontainers.image.created'] }}
             GIT_COMMIT=${{ github.sha }}
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
             VERSION=${{ inputs.version || github.sha }}
+          secrets: |
+            gh_token=${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Generate GitHub SLSA provenance
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/setup-go-private
         with:
           go-version: ${{ env.GO_VERSION }}
-          gh-token: ${{ secrets.GH_PAT }}
+          gh-token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Run tests
         run: make test
@@ -63,7 +63,7 @@ jobs:
       version: ${{ needs.precheck.outputs.tag }}
       push-image: true
     secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
   upload-crds:
     runs-on: ubuntu-24.04
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/setup-go-private
         with:
           go-version: ${{ env.GO_VERSION }}
-          gh-token: ${{ secrets.GH_PAT }}
+          gh-token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Package CRDs
         run: make package-crds VERSION=${{ needs.precheck.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/setup-go-private
         with:
           go-version: ${{ env.GO_VERSION }}
-          gh-token: ${{ secrets.GH_PAT }}
+          gh-token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Install dependencies
         run: go mod download
@@ -35,7 +35,7 @@ jobs:
     with:
       push-image: true
     secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
   e2e:
     name: E2E Tests
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-go-private
         with:
           go-version: ${{ env.GO_VERSION }}
-          gh-token: ${{ secrets.GH_PAT }}
+          gh-token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Login to Registry
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Build the manager binary
 FROM golang:1.24 AS builder
 
-ARG GH_TOKEN
-
 ARG PRIVATE_REPO_HOST=github.com/scality
 
 ARG TARGETOS
@@ -12,16 +10,19 @@ WORKDIR /workspace
 
 RUN go env -w GOPRIVATE=${PRIVATE_REPO_HOST}
 
-RUN if [ -z "$GH_TOKEN" ]; then echo "GH_TOKEN is missing"; exit 1; fi && \
-    git config --global url."https://oauth2:${GH_TOKEN}@${PRIVATE_REPO_HOST}".insteadOf "https://${PRIVATE_REPO_HOST}"
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+# Cache deps before building and copying source. Use BuildKit secret for GH_TOKEN so it
+# never appears in build args or image history. Pass with: --secret id=gh_token,env=GH_TOKEN
+RUN --mount=type=secret,id=gh_token \
+    if [ -f /run/secrets/gh_token ] && [ -s /run/secrets/gh_token ]; then \
+      token=$(cat /run/secrets/gh_token); \
+      git config --global url."https://oauth2:${token}@${PRIVATE_REPO_HOST}".insteadOf "https://${PRIVATE_REPO_HOST}"; \
+    fi && \
+    go mod download && \
+    rm -f /root/.gitconfig
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go


### PR DESCRIPTION
During my tests on deployment-descriptor-operator i was trying to take inspiration from ui-operator.

I figure out that in order to fetch the repository we use the `GH_PAT` token (personal token link to a single github account)

It works, but it's not the most common way. We should use GIT_ACCESS_TOKEN which is an org ENV variable which give us access to others repository (reconciler-framework in our case)

I've also add change the Dockerfile in order to hide the `GIT_ACCESS_TOKEN` in a secret. It's not super critical in our case but still nice to have IMO.

After this PR, we can safely remove the GH_PAT in our settings/secrets